### PR TITLE
Fixed TMap.isEmpty()

### DIFF
--- a/Source/glTFRuntimeDraco/Private/glTFRuntimeDraco.cpp
+++ b/Source/glTFRuntimeDraco/Private/glTFRuntimeDraco.cpp
@@ -70,7 +70,7 @@ static void FillPrimitiveAdditionalBufferViewsFromDraco(TSharedRef<FglTFRuntimeP
 		}
 	}
 
-	if (RequiredAttributes.IsEmpty() && !bRequiresIndices)
+	if (RequiredAttributes.Num() == 0 && !bRequiresIndices)
 	{
 		return;
 	}


### PR DESCRIPTION
TMap.isEmpty() is deprecated and changed it into TMap.Num()